### PR TITLE
New current user

### DIFF
--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -16,6 +16,7 @@ class Spotibetical < Sinatra::Base
 ["/users/profile", "/users/profile/*", "/add_song"].each do |path|
   before path do
     if current_user.nil?
+      session[:error_message] = "You must log in to see this feature."
       session[:return_trip] = path
       redirect to('/users/login')
     end
@@ -97,7 +98,8 @@ end
       current_user.addsong spotify_id
       redirect to('/add_song')
     else
-      @error = "Somebody already suggested that. Be original."
+      #@error = "Somebody already suggested that. Be original."
+      session[:error_message] = "Somebody already suggested that. Be original."
       erb :add_song
     end
   end

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -14,11 +14,11 @@ class Spotibetical < Sinatra::Base
   end
 
 ['/users/profile', "/users/profile/*", "/add_song"].each do |path|
-    before path do
-      if current_user.nil?
-        redirect to('/users/login')
-      end
+  before path do
+    if current_user.nil?
+      redirect to('/users/login')
     end
+  end
 end
 
 
@@ -31,31 +31,19 @@ end
   end
 
   get '/users/profile' do
-    #if current_user
-      erb :user_profile
-    #else
-    #  redirect to('/users/login')
-    #end 
+    erb :user_profile
   end
 
   get '/users/profile/edit' do
-    #if current_user
-      erb :user_profile_edit
-    #else
-    #  redirect to('/users/login')
-    #end 
+    erb :user_profile_edit
   end
 
   patch '/users/profile/edit' do
-    #if current_user
-      u = current_user
-      present_params = params.select { |k,v| v != "" }
-      present_params.delete "_method"
-      u.update present_params if present_params.any?
-      redirect to('/users/profile')
-    #else
-    #  redirect to('/users/login')
-    #end
+    u = current_user
+    present_params = params.select { |k,v| v != "" }
+    present_params.delete "_method"
+    u.update present_params if present_params.any?
+    redirect to('/users/profile')
   end
 
   post '/users/login' do
@@ -67,7 +55,6 @@ end
     if user
       session[:user_id] = user.id
       redirect to('/')
-      # This should probably be connected to the suggested songs display table
     else
       @error = true
       status 422
@@ -102,7 +89,6 @@ end
     # The vote group said adding songs uses a vote so we need to check the user has votes left here
     if Song.find_by(spotify_id: spotify_id).nil?
       current_user.addsong spotify_id
-      #erb :add_song
       redirect to('/add_song')
     else
       @error = "Somebody already suggested that. Be original."

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -37,25 +37,17 @@ end
   end
 
   get '/users/profile/edit' do
-    if current_user
       @states = Madison.states
       @zodiac_signs = %w( Aries Taurus Gemini Cancer Leo Virgo Libra Scorpio Sagittarius Capricorn Aquarius Pisces)
       erb :user_profile_edit
-    else
-      redirect to('/users/login')
-    end 
   end
 
   patch '/users/profile/edit' do
-    if current_user
       u = current_user
       present_params = params.select { |k,v| v != current_user[k] }
       present_params.delete "_method"
       u.update present_params if present_params.any?
       redirect to('/users/profile')
-    else
-      redirect to('/users/login')
-    end
   end
 
   post '/users/login' do
@@ -109,7 +101,6 @@ end
       current_user.addsong spotify_id
       redirect to('/add_song')
     else
-      #@error = "Somebody already suggested that. Be original."
       session[:error_message] = "Somebody already suggested that. Be original."
       erb :add_song
     end

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -13,14 +13,14 @@ class Spotibetical < Sinatra::Base
     end
   end
 
-['/users/profile', "/users/profile/*", "/add_song"].each do |path|
+["/users/profile", "/users/profile/*", "/add_song"].each do |path|
   before path do
     if current_user.nil?
+      session[:return_trip] = path
       redirect to('/users/login')
     end
   end
 end
-
 
   get '/' do
     erb :home
@@ -54,7 +54,13 @@ end
     
     if user
       session[:user_id] = user.id
-      redirect to('/')
+      if session["return_trip"]
+        path = session["return_trip"]
+        redirect to(path)
+        session.delete("return_trip")
+      else
+        redirect to('/')
+      end
     else
       @error = true
       status 422
@@ -63,6 +69,7 @@ end
   end
 
   delete '/users/logout' do
+    binding.pry
     session.delete :user_id
     redirect to('/')
   end

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -13,6 +13,15 @@ class Spotibetical < Sinatra::Base
     end
   end
 
+['/users/profile', "/users/profile/*", "/add_song"].each do |path|
+    before path do
+      if current_user.nil?
+        redirect to('/users/login')
+      end
+    end
+end
+
+
   get '/' do
     erb :home
   end
@@ -22,31 +31,31 @@ class Spotibetical < Sinatra::Base
   end
 
   get '/users/profile' do
-    if current_user
+    #if current_user
       erb :user_profile
-    else
-      redirect to('/users/login')
-    end 
+    #else
+    #  redirect to('/users/login')
+    #end 
   end
 
   get '/users/profile/edit' do
-    if current_user
+    #if current_user
       erb :user_profile_edit
-    else
-      redirect to('/users/login')
-    end 
+    #else
+    #  redirect to('/users/login')
+    #end 
   end
 
   patch '/users/profile/edit' do
-    if current_user
+    #if current_user
       u = current_user
       present_params = params.select { |k,v| v != "" }
       present_params.delete "_method"
       u.update present_params if present_params.any?
       redirect to('/users/profile')
-    else
-      redirect to('/users/login')
-    end
+    #else
+    #  redirect to('/users/login')
+    #end
   end
 
   post '/users/login' do
@@ -72,7 +81,6 @@ class Spotibetical < Sinatra::Base
   end
 
   get '/display' do
-  
     @songs = []
     case  
     when params["sort"] == "alpha"

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -56,8 +56,8 @@ end
       session[:user_id] = user.id
       if session["return_trip"]
         path = session["return_trip"]
-        redirect to(path)
         session.delete("return_trip")
+        redirect to(path)
       else
         redirect to('/')
       end
@@ -69,7 +69,6 @@ end
   end
 
   delete '/users/logout' do
-    binding.pry
     session.delete :user_id
     redirect to('/')
   end

--- a/test/user_auth_test.rb
+++ b/test/user_auth_test.rb
@@ -15,7 +15,9 @@ class UserAuthTest < MiniTest::Test
 
   def setup
     User.delete_all
+    Song.delete_all
     User.create! email: 'brit@kingcons.io', password: 'hunter2', name: 'Brit Butler'
+    Song.create! artist: "Random Artist", title: "Random Song", user_id: 1, spotify_id: "random junk"
   end
 
   def test_users_can_login
@@ -32,7 +34,7 @@ class UserAuthTest < MiniTest::Test
     get '/'
     assert_equal last_response.status, 200
     refute last_response.body.include? "Login"
-    assert last_response.body.include? "Log out"
+    assert last_response.body.include? "Logout"
   end
 
   def test_login_for_redisplays_on_error
@@ -43,5 +45,20 @@ class UserAuthTest < MiniTest::Test
 
   def test_users_can_logout
     skip "Left as an exercise for the reader ..."
+  end
+
+  def test_before_filter 
+    get '/users/profile'
+    assert last_response.redirect?
+
+    post '/add_song', spotify_id: "also random junk"
+    assert last_response.redirect?
+
+    post '/users/login', email: 'brit@kingcons.io', password: 'hunter2'
+    get '/users/profile'
+    assert_equal last_response.status, 200
+
+    get '/add_song'
+    assert_equal last_response.status, 200
   end
 end

--- a/test/user_auth_test.rb
+++ b/test/user_auth_test.rb
@@ -15,9 +15,7 @@ class UserAuthTest < MiniTest::Test
 
   def setup
     User.delete_all
-    Song.delete_all
     User.create! email: 'brit@kingcons.io', password: 'hunter2', name: 'Brit Butler'
-    Song.create! artist: "Random Artist", title: "Random Song", user_id: 1, spotify_id: "random junk"
   end
 
   def test_users_can_login

--- a/views/add_song.erb
+++ b/views/add_song.erb
@@ -1,11 +1,14 @@
-<h3> Suggest a song </h3>
-<h4> Please enter the Spotify ID of the song </h4>
-<% if @error %>
-  <div class="alert alert-danger"><%= @error %></div>
-<% end %>
-<div class="well">
-  <form action='/add_song' method="POST">
-    <input name="spotify_id" placeholder="Spotify ID">
-    <button class="btn btn-primary">Submit</button>
-  </form>
-</div>
+<div class="container">
+  <h3> Suggest a song </h3>
+  <h4> Please enter the Spotify ID of the song </h4>
+    <div class="well">
+      <form action='/add_song' method="POST">
+         <% if session[:error_message] %>
+          <input class="col-sm-3" name="spotify_id" placeholder=<%= params[:spotify_id] %>>
+          <% else %>
+        <input class="col-sm-3" name="spotify_id" placeholder="Spotify ID">
+        <% end %>
+        <button class="btn btn-primary">Submit</button>
+      </form>
+    </div>
+  </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -36,9 +36,17 @@
           <button class="btn btn-primary">Login</button>
         </form>
       </div>
-      <% end %>   
+      <% end %>
     </div>  
   </div>
+  
+  <% if session["error_message"] %>
+    <div>
+      <div class="alert alert-danger" role="alert"><%= session["error_message"] %></div>
+      <% session.delete("error_message") %>
+    </div>
+  <% end %> 
+    
 
   <%= yield %>
 

--- a/views/login.erb
+++ b/views/login.erb
@@ -1,6 +1,5 @@
 <div class="container">
 	<h1>Login</h1>
-	<p class="bg-warning"><strong>Please log in first.</strong></p>
 	<% if @error %>
 	<p class="bg-danger"><strong>Wrong! Try again.</strong></p>
 	<% end %>	


### PR DESCRIPTION
This feature adds::

* A before_filter with an list of specific endpoints. In order to perform any requests to these specific endpoints, a user must be logged in or will be redirected to the login page with an error saying they must be logged in to view the feature. **New handlers must be added to the list at the top of the page if they require user authentication.**
* Once logged in, a user will be redirected to whichever page they were trying to access before encountering the error
* Added a universal error message on the layout above the <% yield %>. These error messages can be customized within various endpoints by setting the sessions[:error_message] to a string. The error message will be removed after it is seen once.