### PR TITLE
Admin playlist

### DIFF
--- a/lib/playlist.rb
+++ b/lib/playlist.rb
@@ -8,7 +8,7 @@ class Playlist < ActiveRecord::Base
     # Figure out which songs won, and add them
     # Look at songs not vetoed
     by_letter = Song.unvetoed.group_by { |s| s.sort_letter }
-    by_letter.each do |letter, songs|
+    by_letter.sort.each do |letter, songs|
       winner = songs.max_by { |s| s.votes.count }
       playlist.songs.push winner
     end

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -155,11 +155,12 @@ class Spotibetical < Sinatra::Base
     end
   end
 
-  get '/create_account' do
+  get '/update_admin' do
     ensure_admin!
-    erb :new_user
-  end
-
+    @users = User.all
+    erb :update_admin
+  end  
+  
   post '/create_account' do
     ensure_admin!
     begin
@@ -183,12 +184,6 @@ class Spotibetical < Sinatra::Base
   # end
 
   #assumes app is private and only open to cohort
-  get '/update_admin' do
-    ensure_admin!
-    @users = User.all
-    erb :update_admin
-  end  
-
   patch '/update_admin' do
     ensure_admin!
     if params["action"] == "enable"

--- a/spotibetical.rb
+++ b/spotibetical.rb
@@ -212,17 +212,19 @@ class Spotibetical < Sinatra::Base
 
   post '/playlist' do
     ensure_admin!
-    session[:playlist] = Playlist.generate_for_week! params['name']
+    playlist = Playlist.generate_for_week! params['name']
+    session[:playlist_id] = playlist.id
     erb :playlist
   end
 
   post '/spotify' do
     ensure_admin!
-    playlist = session[:playlist]
+    playlist = Playlist.find(session[:playlist_id])
     Spotify.create_spotify_playlist playlist
     song_list = playlist.create_uri_list
     Spotify.add_tracks_to_spotify playlist.spotify_id, song_list
-    redirect_to(playlist.spotify_link)
+    binding.pry
+    redirect playlist.spotify_link
   end
 end
 

--- a/views/admin.erb
+++ b/views/admin.erb
@@ -1,0 +1,51 @@
+<!-- new user stuff -->
+
+<div class="container">
+	<div class="col-sm-10">
+		<h2>Create new user account</h2>
+		
+
+		<p class="lead">Enter the user's information below.</p>
+		<form class="form-horizontal" action="/create_account" method="POST" role="form">
+
+      <div class="form-group">
+				<label for="name" class="col-sm-2 control-label">Name</label>
+				<div class="col-sm-6">
+					<input class="form-control" name="name">
+				</div>
+				<p class="help-block">Enter the user's name.</p>
+			</div>
+      
+      <div class="form-group">
+				<label for="name" class="col-sm-2 control-label">Email</label>
+				<div class="col-sm-6">
+					<input class="form-control" name="email">
+				</div>
+				<p class="help-block">Enter the user's email.</p>
+			</div>
+			
+			<div class="form-group">
+				<label for="name" class="col-sm-2 control-label">Password</label>
+				<div class="col-sm-6">
+					<input class="form-control" type= "hidden" name="password" value= "<%= ('a'..'z').to_a.shuffle[0,8 + rand(4)].join %>" >
+				</div>
+				<p class="help-block">The user's password is randomly generated.</p>
+			</div>
+
+			<div class="form-group">
+				<div class="col-sm-offset-2 col-sm-8">
+					<button type="submit" class="btn btn-primary">Submit</button>
+				</div>
+			</div>
+		</form>
+		
+
+	</div>
+	<div class="row">
+	<h2>Make Playlist</h2>
+		<form action="/playlist" method="POST" role="form">
+			<input name="name" placeholder="Enter Playlist Name">
+			<button type="submit" class="btn btn-primary">Submit</button>
+		</form>
+	</div>
+</div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -12,7 +12,7 @@
       <div class="col-sm-1"><a href="/display">Songs</a></div>
       <% if current_user %>
         <% if current_user.admin %>
-          <div class="col-md-1"><a href="/create_account">Add User</a></div>
+          <div class="col-md-1"><a href="/admin">Admin Main</a></div>
           <div class="col-md-1"><a href="/update_admin">Update Admins</a></div>
         <% end %>
         <div class="col-sm-4"></div>

--- a/views/playlist.erb
+++ b/views/playlist.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Artist</th>
+        <th>Song</th>
+        <th>Votes</th>
+      </tr>
+    </thead>
+    <% sorted_songs = session[:playlist].songs.group_by { |s| s.sort_letter }  %>
+    <% sorted_songs.each do |letter, song|  %>
+      <tr>
+        <td><%= song[0].artist %></td>
+        <td><%= song[0].title %></td>
+        <td><%= song[0].votes.count %></td>
+      </tr>
+    <% end %>
+  </table>
+  <form action="/spotify" method="POST" role="form">
+    <button type="submit" class="btn btn-primary">Push Playlist to Spotify!</button>
+  </form>
+</div>

--- a/views/playlist.erb
+++ b/views/playlist.erb
@@ -7,7 +7,7 @@
         <th>Votes</th>
       </tr>
     </thead>
-    <% sorted_songs = session[:playlist].songs.group_by { |s| s.sort_letter }  %>
+    <% sorted_songs = Playlist.find(session[:playlist_id]).songs.group_by { |s| s.sort_letter }  %>
     <% sorted_songs.each do |letter, song|  %>
       <tr>
         <td><%= song[0].artist %></td>


### PR DESCRIPTION
- Main admin route created
- Account creation interface moved to main admin route
- Generate playlist interface moved to main admin route
- Admin can generate a playlist and then view the created playlist
-Admin can push the playlist to spotify
-Admin is redirected to playlist on spotify after push
-Nav bar updated so that Admin can navigate to new admin route.

NOTE: Admin interface redesign and merging of 'update admins' functionality will be in a new branch